### PR TITLE
Fat JAR creation and dockerizing of web app

### DIFF
--- a/common/build.sbt
+++ b/common/build.sbt
@@ -11,3 +11,10 @@ libraryDependencies ++= Seq (
 )
 
 console.settings
+
+assemblyMergeStrategy in assembly := {
+  //  case PathList("cats", "kernel", xs @ _*)         => MergeStrategy.deduplicate
+  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  case "BUILD" => MergeStrategy.discard
+  case _ => MergeStrategy.deduplicate
+}

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -18,3 +18,9 @@ libraryDependencies ++= Seq (
 )
 
 console.settings
+
+assemblyMergeStrategy in assembly := {
+  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  case "BUILD" => MergeStrategy.discard
+  case _ => MergeStrategy.deduplicate
+}

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -19,3 +19,9 @@ libraryDependencies ++= Seq (
 )
 
 console.settings
+
+assemblyMergeStrategy in assembly := {
+  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  case "BUILD" => MergeStrategy.discard
+  case _ => MergeStrategy.deduplicate
+}

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,5 +1,7 @@
 import sbt._, Keys._
 import dependencies._
+import com.typesafe.sbt.packager.docker._
+import com.typesafe.sbt.packager.docker.Dockerfile._
 
 libraryDependencies ++= Seq (
   cats.all,
@@ -25,3 +27,31 @@ assemblyMergeStrategy in assembly := {
   case "BUILD" => MergeStrategy.discard
   case _ => MergeStrategy.deduplicate
 }
+
+// Remove all jar mappings in universal and append the fat jar
+mappings in Universal := {
+  val universalMappings = (mappings in Universal).value
+  val fatJar = (assembly in Compile).value
+  val filtered = universalMappings.filter {
+    case (file, name) => !name.endsWith(".jar")
+  }
+  filtered :+ (fatJar -> ("lib/" + fatJar.getName))
+}
+
+enablePlugins(DockerPlugin, JavaAppPackaging)
+dockerRepository := Some("pulse")
+
+dockerCommands := Seq(
+  Cmd("FROM", "openjdk:8"),
+  Cmd("COPY", "opt/docker/lib/*.jar", "/example-assembly-0.1-SNAPSHOT.jar"),
+  ExecCmd("CMD", "java", "-jar",
+    "-Djava.rmi.server.hostname=example-app",
+    "-Dcom.sun.management.jmxremote",
+    "-Dcom.sun.management.jmxremote.port=4000",
+    "-Dcom.sun.management.jmxremote.rmi.port=4000",
+    "-Dcom.sun.management.jmxremote.local.only=false",
+    "-Dcom.sun.management.jmxremote.authenticate=false",
+    "-Dcom.sun.management.jmxremote.ssl=false",
+    "/example-assembly-0.1-SNAPSHOT.jar")
+)
+

--- a/project.sbt
+++ b/project.sbt
@@ -9,24 +9,5 @@ lazy val pulse_services = project.in(file(".")).aggregate(common, core, example)
 lazy val common	 = project
 
 lazy val core	   = project.dependsOn(common)
-/*
-lazy val core	   = project.dependsOn(common).settings(
-  projectDependencies := {
-    Seq(
-      (projectID in common).value.exclude("org.typelevel", "cats")
-    )
-  }
-)
-*/
 
 lazy val example = project.dependsOn(core)
-
-/*
-lazy val example = project.dependsOn(core).settings(
-  projectDependencies := {
-    Seq(
-      (projectID in core).value.exclude("org.typelevel", "cats")
-    )
-  }
-)
-*/

--- a/project.sbt
+++ b/project.sbt
@@ -9,6 +9,24 @@ lazy val pulse_services = project.in(file(".")).aggregate(common, core, example)
 lazy val common	 = project
 
 lazy val core	   = project.dependsOn(common)
+/*
+lazy val core	   = project.dependsOn(common).settings(
+  projectDependencies := {
+    Seq(
+      (projectID in common).value.exclude("org.typelevel", "cats")
+    )
+  }
+)
+*/
 
 lazy val example = project.dependsOn(core)
 
+/*
+lazy val example = project.dependsOn(core).settings(
+  projectDependencies := {
+    Seq(
+      (projectID in core).value.exclude("org.typelevel", "cats")
+    )
+  }
+)
+*/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("org.wartremover"  % "sbt-wartremover" % "1.2.1")
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")


### PR DESCRIPTION
The `example` project can now be built to produce the JAR file containing all its dependencies:

    sbt example/assembly
The docker container can be created upon that fat JAR using: 

    sbt example/docker:publishLocal
The docker container can be run using the following command:

    docker run -d -P -p 8080:8080 pulse/example:0.1-SNAPSHOT
